### PR TITLE
Reset socket on faulty read

### DIFF
--- a/lib/poseidon/connection.rb
+++ b/lib/poseidon/connection.rb
@@ -140,6 +140,7 @@ module Poseidon
     def read_response(response_class)
       r = ensure_read_or_timeout(4)
       if r.nil?
+        @socket = nil
         Poseidon.logger.debug("Connection failed read_response empty read")
         raise_connection_failed_error
       end

--- a/lib/poseidon/sync_producer.rb
+++ b/lib/poseidon/sync_producer.rb
@@ -145,7 +145,8 @@ module Poseidon
       else
         messages_for_broker.successfully_sent(response)
       end
-    rescue Connection::ConnectionFailedError, Connection::TimeoutException
+    rescue Connection::ConnectionFailedError, Connection::TimeoutException => e
+      Poseidon.logger.debug("Error during send_to_broker: #{e.class}:#{e.message}")
       false
     end
   end


### PR DESCRIPTION
 * empirically tested that connection errors are non-transient and we need to re-estabilish connection
 * add logging in crucial places